### PR TITLE
Add Docker Compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.gitignore
+.pytest_cache
+__pycache__
+*.pyc
+.venv
+venv
+build
+dist
+*.egg-info
+Project.pdf
+docs/project_pdf_extracted*.txt
+tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY pyproject.toml README.md ./
+COPY app ./app
+
+RUN pip install --no-cache-dir .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# substructure-search
+# Substructure Search
+
+Substructure search service for chemical compounds.
+
+The first milestone provides an RDKit-powered core function that accepts a
+collection of molecule SMILES strings and returns the molecules containing a
+requested substructure.
+
+## Development
+
+Install development dependencies:
+
+```bash
+pip install -e ".[dev]"
+```
+
+Run tests:
+
+```bash
+pytest
+```

--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ Run the API locally:
 ```bash
 uvicorn app.main:app --reload
 ```
+
+Run the API with Docker Compose:
+
+```bash
+docker compose up --build
+```
+
+The API will be available at `http://127.0.0.1:8000`, with interactive docs at
+`http://127.0.0.1:8000/docs`.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 Substructure search service for chemical compounds.
 
-The first milestone provides an RDKit-powered core function that accepts a
-collection of molecule SMILES strings and returns the molecules containing a
-requested substructure.
+The current implementation provides:
+
+- an RDKit-powered core function that searches molecule SMILES strings for a
+  requested substructure;
+- a FastAPI application with in-memory molecule CRUD endpoints;
+- a synchronous search endpoint over stored molecules.
 
 ## Development
 
@@ -18,4 +21,10 @@ Run tests:
 
 ```bash
 pytest
+```
+
+Run the API locally:
+
+```bash
+uvicorn app.main:app --reload
 ```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Substructure search application package."""

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -1,0 +1,5 @@
+"""Core cheminformatics functionality."""
+
+from app.core.search import InvalidSmilesError, substructure_search
+
+__all__ = ["InvalidSmilesError", "substructure_search"]

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -1,0 +1,39 @@
+"""RDKit-powered substructure search."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from rdkit import Chem
+
+
+class InvalidSmilesError(ValueError):
+    """Raised when a SMILES string cannot be parsed by RDKit."""
+
+
+def _parse_smiles(smiles: str, *, field_name: str) -> Chem.Mol:
+    molecule = Chem.MolFromSmiles(smiles)
+    if molecule is None:
+        raise InvalidSmilesError(f"Invalid {field_name} SMILES: {smiles!r}")
+    return molecule
+
+
+def substructure_search(molecules: Iterable[str], substructure: str) -> list[str]:
+    """Return molecules that contain the requested substructure.
+
+    Invalid molecule SMILES are skipped so a batch search can still complete.
+    An invalid substructure raises ``InvalidSmilesError`` because the query
+    itself cannot be evaluated.
+    """
+
+    query = _parse_smiles(substructure, field_name="substructure")
+    matches: list[str] = []
+
+    for smiles in molecules:
+        molecule = Chem.MolFromSmiles(smiles)
+        if molecule is None:
+            continue
+        if molecule.HasSubstructMatch(query):
+            matches.append(smiles)
+
+    return matches

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,121 @@
+"""FastAPI application entrypoint."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException, Query, status
+from rdkit import Chem
+from starlette.responses import Response
+
+from app.core import InvalidSmilesError, substructure_search
+from app.repositories import (
+    DuplicateMoleculeError,
+    InMemoryMoleculeRepository,
+    MoleculeNotFoundError,
+    StoredMolecule,
+)
+from app.schemas import (
+    MoleculeCreate,
+    MoleculeRead,
+    MoleculeUpdate,
+    SearchRequest,
+    SearchResponse,
+)
+
+repository = InMemoryMoleculeRepository()
+app = FastAPI(title="Substructure Search")
+
+
+def _to_schema(molecule: StoredMolecule) -> MoleculeRead:
+    return MoleculeRead(identifier=molecule.identifier, smiles=molecule.smiles)
+
+
+def _ensure_valid_molecule_smiles(smiles: str) -> None:
+    if Chem.MolFromSmiles(smiles) is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid molecule SMILES: {smiles!r}",
+        )
+
+
+def _not_found(identifier: str) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=f"Molecule {identifier!r} was not found",
+    )
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post(
+    "/molecules",
+    response_model=MoleculeRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_molecule(payload: MoleculeCreate) -> MoleculeRead:
+    _ensure_valid_molecule_smiles(payload.smiles)
+    molecule = StoredMolecule(identifier=payload.identifier, smiles=payload.smiles)
+    try:
+        return _to_schema(repository.add(molecule))
+    except DuplicateMoleculeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Molecule {payload.identifier!r} already exists",
+        ) from exc
+
+
+@app.get("/molecules/{identifier}", response_model=MoleculeRead)
+def get_molecule(identifier: str) -> MoleculeRead:
+    try:
+        return _to_schema(repository.get(identifier))
+    except MoleculeNotFoundError as exc:
+        raise _not_found(identifier) from exc
+
+
+@app.put("/molecules/{identifier}", response_model=MoleculeRead)
+def update_molecule(identifier: str, payload: MoleculeUpdate) -> MoleculeRead:
+    _ensure_valid_molecule_smiles(payload.smiles)
+    try:
+        return _to_schema(repository.update(identifier, smiles=payload.smiles))
+    except MoleculeNotFoundError as exc:
+        raise _not_found(identifier) from exc
+
+
+@app.delete("/molecules/{identifier}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_molecule(identifier: str) -> Response:
+    try:
+        repository.delete(identifier)
+    except MoleculeNotFoundError as exc:
+        raise _not_found(identifier) from exc
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@app.get("/molecules", response_model=list[MoleculeRead])
+def list_molecules(limit: int | None = Query(default=None, ge=0)) -> list[MoleculeRead]:
+    return [_to_schema(molecule) for molecule in repository.list(limit=limit)]
+
+
+@app.post("/search", response_model=SearchResponse)
+def search(payload: SearchRequest) -> SearchResponse:
+    molecules = list(repository.list())
+    try:
+        matched_smiles = substructure_search(
+            (molecule.smiles for molecule in molecules),
+            payload.substructure,
+        )
+    except InvalidSmilesError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+
+    remaining = list(matched_smiles)
+    matches: list[MoleculeRead] = []
+    for molecule in molecules:
+        if molecule.smiles in remaining:
+            matches.append(_to_schema(molecule))
+            remaining.remove(molecule.smiles)
+
+    return SearchResponse(substructure=payload.substructure, matches=matches)

--- a/app/repositories/__init__.py
+++ b/app/repositories/__init__.py
@@ -1,0 +1,15 @@
+"""Repository implementations."""
+
+from app.repositories.memory import (
+    DuplicateMoleculeError,
+    InMemoryMoleculeRepository,
+    MoleculeNotFoundError,
+    StoredMolecule,
+)
+
+__all__ = [
+    "DuplicateMoleculeError",
+    "InMemoryMoleculeRepository",
+    "MoleculeNotFoundError",
+    "StoredMolecule",
+]

--- a/app/repositories/memory.py
+++ b/app/repositories/memory.py
@@ -1,0 +1,64 @@
+"""In-memory molecule repository used before the database milestone."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class StoredMolecule:
+    """Molecule record stored by the application."""
+
+    identifier: str
+    smiles: str
+
+
+class MoleculeNotFoundError(KeyError):
+    """Raised when a molecule identifier is not present in storage."""
+
+
+class DuplicateMoleculeError(ValueError):
+    """Raised when a molecule identifier already exists."""
+
+
+class InMemoryMoleculeRepository:
+    """Small repository backed by a dictionary."""
+
+    def __init__(self) -> None:
+        self._molecules: dict[str, StoredMolecule] = {}
+
+    def add(self, molecule: StoredMolecule) -> StoredMolecule:
+        if molecule.identifier in self._molecules:
+            raise DuplicateMoleculeError(molecule.identifier)
+        self._molecules[molecule.identifier] = molecule
+        return molecule
+
+    def get(self, identifier: str) -> StoredMolecule:
+        try:
+            return self._molecules[identifier]
+        except KeyError as exc:
+            raise MoleculeNotFoundError(identifier) from exc
+
+    def update(self, identifier: str, *, smiles: str) -> StoredMolecule:
+        if identifier not in self._molecules:
+            raise MoleculeNotFoundError(identifier)
+        molecule = StoredMolecule(identifier=identifier, smiles=smiles)
+        self._molecules[identifier] = molecule
+        return molecule
+
+    def delete(self, identifier: str) -> None:
+        if identifier not in self._molecules:
+            raise MoleculeNotFoundError(identifier)
+        del self._molecules[identifier]
+
+    def list(self, *, limit: int | None = None) -> Iterator[StoredMolecule]:
+        count = 0
+        for molecule in self._molecules.values():
+            if limit is not None and count >= limit:
+                return
+            yield molecule
+            count += 1
+
+    def clear(self) -> None:
+        self._molecules.clear()

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,17 @@
+"""API schemas."""
+
+from app.schemas.molecules import (
+    MoleculeCreate,
+    MoleculeRead,
+    MoleculeUpdate,
+    SearchRequest,
+    SearchResponse,
+)
+
+__all__ = [
+    "MoleculeCreate",
+    "MoleculeRead",
+    "MoleculeUpdate",
+    "SearchRequest",
+    "SearchResponse",
+]

--- a/app/schemas/molecules.py
+++ b/app/schemas/molecules.py
@@ -1,0 +1,26 @@
+"""Pydantic schemas for molecule APIs."""
+
+from pydantic import BaseModel, Field
+
+
+class MoleculeCreate(BaseModel):
+    identifier: str = Field(..., min_length=1)
+    smiles: str = Field(..., min_length=1)
+
+
+class MoleculeUpdate(BaseModel):
+    smiles: str = Field(..., min_length=1)
+
+
+class MoleculeRead(BaseModel):
+    identifier: str
+    smiles: str
+
+
+class SearchRequest(BaseModel):
+    substructure: str = Field(..., min_length=1)
+
+
+class SearchResponse(BaseModel):
+    substructure: str
+    matches: list[MoleculeRead]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  api:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      SERVER_ID: api-1
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "from urllib.request import urlopen; urlopen('http://127.0.0.1:8000/health').read()"
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/docs/project_plan.md
+++ b/docs/project_plan.md
@@ -1,0 +1,231 @@
+# Project Execution Plan
+
+Goal: build a FastAPI substructure search service with RDKit, Docker, PostgreSQL, Redis caching, Celery, tests, and CI. Each major component is implemented in a separate issue branch and merged through a pull request.
+
+## Branching Strategy
+
+Integration branch: `main`.
+
+Issue branches must use the format `<issue-number>-<short-name>`.
+
+Planned component branches:
+
+| Branch Example | Component | Result |
+|---|---|---|
+| `1-rdkit-search-core` | RDKit core | Project bootstrap, pure substructure search function, SMILES validation, unit tests |
+| `<issue>-fastapi-crud-ram` | FastAPI + RAM storage | CRUD API, RAM-backed search endpoint, OpenAPI docs |
+| `<issue>-docker-compose-app` | Docker | `Dockerfile`, `docker-compose.yml`, API container with RDKit |
+| `<issue>-nginx-balancing` | nginx | Two web instances, nginx proxy, `server_id` endpoint |
+| `<issue>-tests-ci-flake8` | Quality gate | pytest coverage for core/API, GitHub Actions, flake8 |
+| `<issue>-postgres-sqlalchemy` | Database | PostgreSQL, SQLAlchemy repository, `.env` configuration |
+| `<issue>-logging-iterator` | Logging + iterator | Structured logs, `limit` for molecule listing, iterator-based retrieval |
+| `<issue>-redis-cache` | Redis cache | Search cache hit/miss, TTL, Redis in Compose |
+| `<issue>-celery-search` | Celery async search | Search task endpoint, task status/result endpoint, worker in Compose |
+| `<issue>-file-upload` | Optional upload | Molecule file upload if time permits |
+
+## Architecture
+
+```mermaid
+flowchart LR
+    API["FastAPI routers"] --> SVC["Services"]
+    SVC --> CORE["RDKit search core"]
+    SVC --> REPO["Repository interface"]
+    REPO --> RAM["RAM repository"]
+    REPO --> PG[("PostgreSQL")]
+    SVC --> CACHE["Redis cache"]
+    API --> TASKS["Celery task API"]
+    TASKS --> WORKER["Celery worker"]
+    WORKER --> CORE
+    WORKER --> REPO
+    WORKER --> CACHE
+    NGINX["nginx"] --> API
+```
+
+## Implementation Milestones
+
+### 1. Project Bootstrap And RDKit Search Core
+
+- Create the Python package structure under `app/`.
+- Split code into future-ready modules such as `core`, `api`, `schemas`, `services`, and `repositories` as they become necessary.
+- Add minimal dependency and test configuration.
+- Implement `substructure_search(molecules: list[str], substructure: str) -> list[str]`.
+- Use `Chem.MolFromSmiles` and `HasSubstructMatch`.
+- Define invalid input behavior:
+  - invalid substructure raises a validation error;
+  - invalid molecules in the input list are skipped so a batch search can still complete.
+- Add tests for benzene, carboxylic acid, no matches, empty input, and invalid input.
+
+Ready when: core unit tests pass and the project imports cleanly.
+
+### 2. FastAPI CRUD With RAM Storage
+
+- Add Pydantic models:
+  - `MoleculeCreate`;
+  - `MoleculeUpdate`;
+  - `MoleculeRead`;
+  - `SearchRequest`;
+  - `SearchResponse`.
+- Implement endpoints:
+  - `POST /molecules`;
+  - `GET /molecules/{identifier}`;
+  - `PUT /molecules/{identifier}`;
+  - `DELETE /molecules/{identifier}`;
+  - `GET /molecules`;
+  - `POST /search`;
+  - `GET /health` or `/`.
+- Use an in-memory repository for this stage.
+- Return clear status codes: `201`, `200`, `204`, `400/422`, `404`, and `409`.
+
+Ready when: CRUD and search are available through `/docs` and covered by tests.
+
+### 3. Docker Compose For The Application
+
+- Add `Dockerfile`.
+- Add `.dockerignore`.
+- Add `docker-compose.yml` with the web service.
+- Ensure RDKit installs successfully inside the container.
+- Expose port `8000`.
+
+Ready when: `docker compose up --build` starts the API and `/docs` is reachable.
+
+### 4. nginx Balancing
+
+- Add `nginx/default.conf`.
+- Run `web1`, `web2`, and `nginx` services in Compose.
+- Add an endpoint that returns `server_id` from the environment.
+- Configure nginx upstream across both web services.
+
+Ready when: requests through nginx return both server IDs over repeated calls.
+
+### 5. Tests, CI, And flake8
+
+- Expand pytest coverage:
+  - core tests;
+  - API tests through FastAPI TestClient;
+  - repository behavior;
+  - negative cases.
+- Add `flake8`.
+- Add GitHub Actions workflow:
+  - checkout;
+  - setup Python;
+  - install dependencies;
+  - run flake8;
+  - run pytest.
+
+Ready when: CI passes after push.
+
+### 6. PostgreSQL And SQLAlchemy
+
+- Add a `db` service to Compose.
+- Move credentials to `.env`.
+- Add SQLAlchemy model `Molecule`.
+- Implement a repository interface and SQLAlchemy repository.
+- Switch the API services from RAM to PostgreSQL.
+- Keep the RAM repository useful for unit tests.
+
+Ready when: stored molecules survive a web container restart.
+
+### 7. Logging And Iterator-Based Listing
+
+- Configure standard `logging`.
+- Add logs to CRUD, search, cache, and task flows.
+- Add `limit` to `GET /molecules`.
+- Implement repository/service listing as iterator-friendly retrieval.
+- Validate edge cases for `limit`.
+
+Ready when: listing respects `limit` and logs show key actions.
+
+### 8. Redis Search Cache
+
+- Add a Redis service to Compose.
+- Implement a cache service.
+- Include both the substructure and current dataset version in the search cache key, or invalidate search keys after CRUD changes.
+- Add TTL.
+- Return search results from Redis on cache hit.
+
+Ready when: repeated identical searches are served from Redis until TTL expiry or dataset change.
+
+### 9. Celery Async Search
+
+- Add Celery dependencies.
+- Configure Redis as broker/backend.
+- Add a worker service to Compose.
+- Change search API:
+  - `POST /search/tasks` starts a task and returns `task_id`;
+  - `GET /search/tasks/{task_id}` returns status and result;
+  - synchronous `POST /search` may remain as a shortcut if it does not conflict with the assignment.
+- Reuse the same services/repositories/cache inside Celery tasks.
+
+Ready when: search runs asynchronously and status/result are available through a separate request.
+
+### 10. Optional File Upload
+
+- Pick a simple format: CSV or JSON.
+- Add `POST /molecules/upload`.
+- Validate rows and return an import report: added, skipped, and errors.
+
+Ready when: uploading a file adds valid molecules to storage.
+
+## Integration Order
+
+```mermaid
+gitGraph
+    commit id: "main"
+    branch "1-rdkit-search-core"
+    checkout "1-rdkit-search-core"
+    commit id: "core"
+    checkout main
+    merge "1-rdkit-search-core"
+    branch "2-fastapi-crud-ram"
+    checkout "2-fastapi-crud-ram"
+    commit id: "api-ram"
+    checkout main
+    merge "2-fastapi-crud-ram"
+    branch "3-docker-compose-app"
+    checkout "3-docker-compose-app"
+    commit id: "docker"
+    checkout main
+    merge "3-docker-compose-app"
+    branch "4-nginx-balancing"
+    checkout "4-nginx-balancing"
+    commit id: "nginx"
+    checkout main
+    merge "4-nginx-balancing"
+```
+
+## Initial API Contract
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/health` | Health check |
+| `GET` | `/server` | nginx balancing check through `server_id` |
+| `POST` | `/molecules` | Create molecule |
+| `GET` | `/molecules/{identifier}` | Get molecule |
+| `PUT` | `/molecules/{identifier}` | Update molecule |
+| `DELETE` | `/molecules/{identifier}` | Delete molecule |
+| `GET` | `/molecules?limit=100` | List molecules with limit |
+| `POST` | `/search` | Synchronous search before Celery |
+| `POST` | `/search/tasks` | Start asynchronous search after Celery |
+| `GET` | `/search/tasks/{task_id}` | Read task status/result |
+| `POST` | `/molecules/upload` | Optional molecule file upload |
+
+## Risks And Decisions
+
+| Risk | Decision |
+|---|---|
+| RDKit installation can be fragile in containers | Verify the container build early and pin a working dependency set |
+| Search cache can become stale after CRUD changes | Add a dataset version to cache keys or invalidate search keys on mutation |
+| Celery worker can drift from API configuration | Use shared settings and the same Compose environment variables |
+| PostgreSQL/Redis integration tests can be heavy | Keep core/API tests isolated, then add a smaller integration suite |
+| nginx can hide failing web services | Add health endpoints and inspect container logs |
+
+## Definition Of Done
+
+- All mandatory homework requirements from the PDF are implemented.
+- The application starts through Docker Compose.
+- CRUD, search, Redis cache, and Celery workflows are documented in OpenAPI.
+- PostgreSQL preserves molecules across restarts.
+- nginx distributes requests between two web instances.
+- pytest and flake8 pass locally and in GitHub Actions.
+- Logs are useful enough to diagnose the main operations.
+- `docs/` contains up-to-date English documentation.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,138 @@
+# Requirements Analysis From Project.pdf
+
+Source: `Project.pdf`. The PDF was extracted automatically. Some code examples and dates are partially corrupted by embedded font encoding, so the requirements below are normalized from the readable homework sections.
+
+## Project Goal
+
+Build a substructure search service for chemical compounds. Users store molecules as SMILES strings, submit a substructure query, and receive all stored molecules that contain that substructure.
+
+## Functional Requirements
+
+1. Implement the RDKit substructure search core:
+   - input 1: a list of molecules as SMILES strings;
+   - input 2: a substructure as a SMILES string;
+   - output: all molecules from the input list that contain the substructure;
+   - use RDKit for molecule parsing and substructure matching;
+   - the PDF example expects `c1ccccc1` to match benzene-containing molecules.
+
+2. Implement a FastAPI server around the algorithm:
+   - add a molecule by `identifier` and `smiles`;
+   - get a molecule by `identifier`;
+   - update a molecule by `identifier`;
+   - delete a molecule by `identifier`;
+   - list all molecules;
+   - run substructure search across all added molecules;
+   - optional: upload a file with molecules, with the file format chosen by the implementer.
+
+3. Start with in-memory molecule storage:
+   - standard data structures such as dictionaries are acceptable;
+   - data is allowed to disappear after application restart during this stage.
+
+4. Add Docker support:
+   - provide a `Dockerfile` for the Python FastAPI application;
+   - provide `docker-compose.yml`;
+   - install `rdkit` in the application container;
+   - run the app through Uvicorn on port `8000`.
+
+5. Add nginx load balancing:
+   - run at least two web application instances;
+   - add nginx as a reverse proxy;
+   - add an API method that returns `server_id` from the environment;
+   - repeated requests through nginx should demonstrate traffic distribution between web containers.
+
+6. Add tests for the riskiest part:
+   - cover the substructure search function;
+   - include positive and negative cases;
+   - include empty input and invalid SMILES/substructure cases.
+
+7. Add CI:
+   - GitHub Actions must run tests after each push;
+   - add static analysis with `flake8`.
+
+8. Add PostgreSQL:
+   - replace RAM storage with persistent molecule storage;
+   - add a `postgres` service to Docker Compose;
+   - keep credentials in `.env`;
+   - use SQLAlchemy for database access.
+
+9. Add logging:
+   - use the standard `logging` package;
+   - log key application activity: CRUD operations, search, validation errors, cache hit/miss, and task lifecycle events.
+
+10. Add iterator-based listing with `limit`:
+    - update the list-all-molecules API method;
+    - add a `limit` argument;
+    - return at most the requested number of molecules;
+    - implement the retrieval path as an iterator-friendly flow.
+
+11. Add Redis caching for search results:
+    - integrate Redis through Docker Compose;
+    - check Redis before running search;
+    - return cached search results on cache hit;
+    - on cache miss, run the search, cache the result, and return it;
+    - cached search results must have a TTL;
+    - tests or manual verification must show that repeated search requests use Redis.
+
+12. Add Celery:
+    - use Redis as broker/backend;
+    - change the substructure search API to an asynchronous workflow;
+    - one request starts a search task;
+    - another request reads task status and returns the result when ready;
+    - run the Celery worker as a separate Docker Compose service.
+
+## Non-Functional Requirements
+
+- The project must be reproducible through Docker Compose.
+- The API should expose clear request/response models and standard HTTP status codes.
+- Invalid SMILES, missing identifiers, and duplicate identifiers must be handled explicitly.
+- Tests and `flake8` must pass in CI.
+- Logs must make the main application activity understandable without `print`.
+- After the PostgreSQL stage, molecules must survive web application restarts.
+- Search cache keys must account for the query and the current molecule dataset state.
+
+## Main Request Flow
+
+```mermaid
+flowchart TD
+    A["Client"] --> B["FastAPI API"]
+    B --> C{"Operation"}
+    C -->|CRUD molecule| D["Molecule service"]
+    D --> E["Repository"]
+    E --> F[("PostgreSQL")]
+    C -->|Substructure search| G["Search service"]
+    G --> H{"Redis cache hit?"}
+    H -->|Yes| I["Return cached result"]
+    H -->|No| J["RDKit matcher"]
+    J --> K["Cache result with TTL"]
+    K --> L["Return result"]
+```
+
+## Async Search Flow After Celery
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API as FastAPI
+    participant Redis as Redis Broker/Cache
+    participant Worker as Celery Worker
+    participant DB as PostgreSQL
+
+    Client->>API: POST /search/tasks
+    API->>Redis: enqueue search task
+    API-->>Client: task_id, status
+    Worker->>Redis: consume task
+    Worker->>DB: load molecules
+    Worker->>Redis: check cached result
+    alt cache miss
+        Worker->>Worker: RDKit substructure search
+        Worker->>Redis: store result with TTL
+    end
+    Client->>API: GET /search/tasks/{task_id}
+    API->>Redis: read task state/result
+    API-->>Client: pending/started/success/failure + result
+```
+
+## PDF Notes
+
+- The PDF includes a `Deadlines` section, but its dates and work numbers are partially corrupted during extraction. The readable content indicates a sequence of staged project submissions.
+- All homework blocks from the PDF are covered here: RDKit, FastAPI, Docker, nginx, testing, CI, database, logging/iterator, Redis, and Celery.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "substructure-search"
+version = "0.1.0"
+description = "Substructure search service for chemical compounds."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "rdkit>=2023.9.1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,14 @@ description = "Substructure search service for chemical compounds."
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+    "fastapi>=0.110",
     "rdkit>=2023.9.1",
+    "uvicorn[standard]>=0.27",
 ]
 
 [project.optional-dependencies]
 dev = [
+    "httpx>=0.27",
     "pytest>=8.0",
 ]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,113 @@
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app, repository
+
+
+@pytest.fixture(autouse=True)
+def clear_repository() -> Iterator[None]:
+    repository.clear()
+    yield
+    repository.clear()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def test_health_check(client: TestClient) -> None:
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_creates_and_reads_molecule(client: TestClient) -> None:
+    create_response = client.post(
+        "/molecules",
+        json={"identifier": "ethanol", "smiles": "CCO"},
+    )
+
+    assert create_response.status_code == 201
+    assert create_response.json() == {"identifier": "ethanol", "smiles": "CCO"}
+
+    read_response = client.get("/molecules/ethanol")
+
+    assert read_response.status_code == 200
+    assert read_response.json() == {"identifier": "ethanol", "smiles": "CCO"}
+
+
+def test_rejects_duplicate_identifier(client: TestClient) -> None:
+    payload = {"identifier": "benzene", "smiles": "c1ccccc1"}
+
+    assert client.post("/molecules", json=payload).status_code == 201
+    response = client.post("/molecules", json=payload)
+
+    assert response.status_code == 409
+
+
+def test_rejects_invalid_molecule_smiles(client: TestClient) -> None:
+    response = client.post(
+        "/molecules",
+        json={"identifier": "bad", "smiles": "not-smiles"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_updates_molecule(client: TestClient) -> None:
+    client.post("/molecules", json={"identifier": "sample", "smiles": "CCO"})
+
+    response = client.put("/molecules/sample", json={"smiles": "CCN"})
+
+    assert response.status_code == 200
+    assert response.json() == {"identifier": "sample", "smiles": "CCN"}
+
+
+def test_deletes_molecule(client: TestClient) -> None:
+    client.post("/molecules", json={"identifier": "sample", "smiles": "CCO"})
+
+    delete_response = client.delete("/molecules/sample")
+    read_response = client.get("/molecules/sample")
+
+    assert delete_response.status_code == 204
+    assert read_response.status_code == 404
+
+
+def test_lists_molecules_with_limit(client: TestClient) -> None:
+    client.post("/molecules", json={"identifier": "one", "smiles": "CCO"})
+    client.post("/molecules", json={"identifier": "two", "smiles": "CCN"})
+
+    response = client.get("/molecules", params={"limit": 1})
+
+    assert response.status_code == 200
+    assert response.json() == [{"identifier": "one", "smiles": "CCO"}]
+
+
+def test_searches_stored_molecules(client: TestClient) -> None:
+    client.post("/molecules", json={"identifier": "ethanol", "smiles": "CCO"})
+    client.post("/molecules", json={"identifier": "benzene", "smiles": "c1ccccc1"})
+    client.post(
+        "/molecules",
+        json={"identifier": "aspirin", "smiles": "CC(=O)Oc1ccccc1C(=O)O"},
+    )
+
+    response = client.post("/search", json={"substructure": "c1ccccc1"})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "substructure": "c1ccccc1",
+        "matches": [
+            {"identifier": "benzene", "smiles": "c1ccccc1"},
+            {"identifier": "aspirin", "smiles": "CC(=O)Oc1ccccc1C(=O)O"},
+        ],
+    }
+
+
+def test_rejects_invalid_search_substructure(client: TestClient) -> None:
+    response = client.post("/search", json={"substructure": "not-smiles"})
+
+    assert response.status_code == 422

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,44 @@
+import pytest
+
+from app.core import InvalidSmilesError, substructure_search
+
+
+def test_finds_benzene_substructure() -> None:
+    molecules = ["CCO", "c1ccccc1", "CC(=O)Oc1ccccc1C(=O)O"]
+
+    result = substructure_search(molecules, "c1ccccc1")
+
+    assert result == ["c1ccccc1", "CC(=O)Oc1ccccc1C(=O)O"]
+
+
+def test_finds_carboxylic_acid_substructure() -> None:
+    molecules = ["CCO", "CC(=O)O", "Cc1ccccc1"]
+
+    result = substructure_search(molecules, "C(=O)O")
+
+    assert result == ["CC(=O)O"]
+
+
+def test_returns_empty_list_when_no_molecules_match() -> None:
+    molecules = ["CCO", "CCN"]
+
+    result = substructure_search(molecules, "c1ccccc1")
+
+    assert result == []
+
+
+def test_returns_empty_list_for_empty_input() -> None:
+    assert substructure_search([], "c1ccccc1") == []
+
+
+def test_skips_invalid_molecules_in_batch() -> None:
+    molecules = ["not-smiles", "c1ccccc1"]
+
+    result = substructure_search(molecules, "c1ccccc1")
+
+    assert result == ["c1ccccc1"]
+
+
+def test_raises_for_invalid_substructure() -> None:
+    with pytest.raises(InvalidSmilesError):
+        substructure_search(["c1ccccc1"], "not-smiles")


### PR DESCRIPTION
## Summary
- Add Dockerfile for the FastAPI application.
- Add .dockerignore to keep local/project-only artifacts out of the image context.
- Add docker-compose.yml for the API service on port 8000.
- Install the project and RDKit dependencies in the container image.
- Run the app with Uvicorn and add a container healthcheck.
- Document Docker Compose startup in README.

## Development
Closes #5
Depends on #1, #3, PR #2, and PR #4.

## Testing
- `docker compose config` passes and renders a valid Compose model.
- `docker compose build` not completed: Docker daemon is unavailable in this environment (`dockerDesktopLinuxEngine` pipe not found).
- Python tests were not run locally: the environment has the Python launcher, but no installed Python runtime (`py -m pytest` returns `No installed Python found!`).